### PR TITLE
Added capture to fix "divide by zero" log errors for 0 cost pieces

### DIFF
--- a/Patches/HUDPatches.cs
+++ b/Patches/HUDPatches.cs
@@ -41,10 +41,10 @@ public class HUDPatches
                 int containerItemCount = containers.Sum(c => c.ContainsItem(itemName, 1, out int result) ? result : 0);
                 containerItemCount = Boxes.CheckAndDecrement(containerItemCount);
 #if DEBUG
-                AzuCraftyBoxesPlugin.AzuCraftyBoxesLogger.LogIfReleaseAndDebugEnable($"Found {playerItemCount} {itemName} in player inventory and {containerItemCount} in containers, returning {(playerItemCount + containerItemCount) / resource.m_amount}");
+                AzuCraftyBoxesPlugin.AzuCraftyBoxesLogger.LogIfReleaseAndDebugEnable($"Found {playerItemCount} {itemName} in player inventory and {containerItemCount} in containers, returning {(resource.m_amount > 0 ? (playerItemCount + containerItemCount) / resource.m_amount : "∞")}");
 #endif
                 
-                return (playerItemCount + containerItemCount) / resource.m_amount;
+                return resource.m_amount > 0 ? (playerItemCount + containerItemCount) / resource.m_amount : int.MaxValue;
             }).Concat(new[] { int.MaxValue }).Min();
     }
 }


### PR DESCRIPTION
Added capture to fix "divide by zero" log errors in scenarios where pieces are modified to have no build requirements.  The change also helps properly display the infinity symbol in the build menu for these items.

For example, creating a recipe with WackyDB to have a portal require no materials to build resulted in divide by zero log errors and the craftable amount in the build menu would flicker between infinity and 0.

![Screenshot 2025-01-23 145622](https://github.com/user-attachments/assets/12ca0e32-0877-4316-8eab-f9e539bd6d6d)